### PR TITLE
update loop item creation endpoint docs to include asset block

### DIFF
--- a/nowsignage-v2-open-api.yml
+++ b/nowsignage-v2-open-api.yml
@@ -1221,6 +1221,15 @@ components:
         position:
           type: integer
           example: 1
+        asset:
+          type: object
+          properties:
+            id:
+              type: integer
+              example: "1"
+            type:
+              type: string
+              example: "image"
         external_url:
           type: string
           example: ""


### PR DESCRIPTION
The documentation for the loop item creation endpoint has been updated to reflect the required asset block (with id and type, either image or video). 
Previously, the endpoint allowed creating a loop item but did not document how to attach an asset.